### PR TITLE
Fix: Incorrect conversion between integer types

### DIFF
--- a/normalize_url/internal/ip/ip.go
+++ b/normalize_url/internal/ip/ip.go
@@ -30,7 +30,7 @@ func NormalizeIPv4(s string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		resultRow += strconv.Itoa(int(num)) + "."
+		resultRow += strconv.FormatUint(uint64(num), 10) + "."
 	}
 
 	num, err := parseNumber(octets[len(octets)-1], 5-len(octets))


### PR DESCRIPTION
This PR fixes an issue in `normalize_url/internal/ip/ip.go` where converting `uint32` to `int` caused potential overflow. 
However, Switched to `strconv.FormatUint(uint64(num), 10)` to safely handle all `uint32` values without any risk. 